### PR TITLE
[Feature 4E] Dark Horse Alert

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -283,6 +283,47 @@ function App() {
     .sort((a, b) => parseInt(b.updated) - parseInt(a.updated))
     .slice(0, 10);
 
+  // Dark Horse Alert: Players who could surge to top positions
+  const unansweredCount = latestQuestions.filter(q => !q.answer).length;
+  const darkHorses = (() => {
+    if (unansweredCount === 0 || players.length < 4) return [];
+
+    // Get current top 3 scores
+    const sortedByScore = [...players].sort((a, b) => b.score - a.score);
+    const top3Score = sortedByScore[2]?.score ?? 0; // 3rd place score
+    const leaderScore = sortedByScore[0]?.score ?? 0;
+
+    // Find players outside top 3 who could jump into top 3
+    return players
+      .filter((p) => {
+        const currentRank = rankMap.get(p.score)?.rank ?? 999;
+        if (currentRank <= 3) return false; // Already in top 3
+
+        const bestCaseScore = p.score + unansweredCount;
+        // Could they beat current 3rd place?
+        return bestCaseScore > top3Score;
+      })
+      .map((p) => {
+        const bestCaseScore = p.score + unansweredCount;
+        // Calculate best case rank
+        let bestRank = 1;
+        for (const other of players) {
+          if (other.email !== p.email && other.score > bestCaseScore) {
+            bestRank++;
+          }
+        }
+        return {
+          ...p,
+          currentRank: rankMap.get(p.score)?.rank ?? 999,
+          bestCaseScore,
+          bestCaseRank: bestRank,
+          couldBeatLeader: bestCaseScore > leaderScore,
+        };
+      })
+      .sort((a, b) => a.bestCaseRank - b.bestCaseRank)
+      .slice(0, 3); // Top 3 dark horses
+  })();
+
   return (
     <div className="focused-app">
       <div className="focused-container">
@@ -353,6 +394,30 @@ function App() {
                 >
                   Find Me
                 </button>
+              </div>
+            )}
+
+            {/* Dark Horse Alert */}
+            {darkHorses.length > 0 && (
+              <div className="focused-dark-horse-alert">
+                <div className="focused-dark-horse-header">
+                  <span className="focused-dark-horse-icon">🐴</span>
+                  <span className="focused-dark-horse-title">Dark Horse Alert</span>
+                </div>
+                <div className="focused-dark-horse-list">
+                  {darkHorses.map((horse, idx) => (
+                    <div key={horse.email} className="focused-dark-horse-item">
+                      <span className="focused-dark-horse-name">{horse.name}</span>
+                      <span className="focused-dark-horse-potential">
+                        #{horse.currentRank} → could be <strong>#{horse.bestCaseRank}</strong>
+                        {horse.couldBeatLeader && <span className="focused-dark-horse-crown">👑</span>}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <div className="focused-dark-horse-footer">
+                  {unansweredCount} questions remaining
+                </div>
               </div>
             )}
 

--- a/src/FocusedDesign.css
+++ b/src/FocusedDesign.css
@@ -726,3 +726,85 @@ body {
   font-size: 0.9rem;
   margin-bottom: 1rem;
 }
+
+/* ==================== DARK HORSE ALERT ==================== */
+.focused-dark-horse-alert {
+  background: linear-gradient(135deg, rgba(240, 136, 62, 0.15) 0%, rgba(240, 136, 62, 0.08) 100%);
+  border: 1px solid rgba(240, 136, 62, 0.4);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.focused-dark-horse-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.focused-dark-horse-icon {
+  font-size: 1.25rem;
+}
+
+.focused-dark-horse-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #f0883e;
+}
+
+.focused-dark-horse-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.focused-dark-horse-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+}
+
+.focused-dark-horse-name {
+  font-size: 0.85rem;
+  color: #c9d1d9;
+  font-weight: 500;
+}
+
+.focused-dark-horse-potential {
+  font-size: 0.75rem;
+  color: #8b949e;
+}
+
+.focused-dark-horse-potential strong {
+  color: #f0883e;
+}
+
+.focused-dark-horse-crown {
+  margin-left: 0.25rem;
+}
+
+.focused-dark-horse-footer {
+  margin-top: 0.5rem;
+  font-size: 0.7rem;
+  color: #8b949e;
+  text-align: center;
+}
+
+/* Mobile adjustments for Dark Horse */
+@media (max-width: 480px) {
+  .focused-dark-horse-alert {
+    padding: 0.75rem;
+  }
+
+  .focused-dark-horse-item {
+    padding: 0.4rem 0.6rem;
+  }
+
+  .focused-dark-horse-name {
+    font-size: 0.8rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Dark Horse Alert section highlighting players who could surge
- Calculates best-case rank based on unanswered questions
- Shows players outside top 3 who could jump into top positions
- Crown emoji indicates players who could beat the current leader

## Changes
- `src/App.js`: Added `darkHorses` calculation and alert UI
- `src/FocusedDesign.css`: Added orange-tinted styling for alert

## Test plan
- [x] Verify alert appears when unanswered questions exist
- [x] Verify shows players who could reach top 3
- [x] Verify crown emoji shows for potential leaders
- [x] Verify alert hidden when no dark horses exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)